### PR TITLE
Delay before hide tooltip

### DIFF
--- a/plugins/sigma.plugins.tooltips/sigma.plugins.tooltips.js
+++ b/plugins/sigma.plugins.tooltips/sigma.plugins.tooltips.js
@@ -432,7 +432,7 @@
           self.dispatchEvent('shown', event.data);
         }, no.delay);
       });
-
+      //TODO delay before hide
       s.bind(no.hide, function(event) {
         var p = _tooltip;
         cancel();
@@ -489,6 +489,7 @@
         }, eo.delay);
       });
 
+      //TODO delay before hide
       s.bind(eo.hide, function(event) {
         var p = _tooltip;
         cancel();


### PR DESCRIPTION
Need a delay time from the hide tooltip event (outNode,outEdge) and the actual hide tooltip action, in order to make the buttons on tooltip actually clickable.
